### PR TITLE
DB-1049: add wp-webhooks as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "wp-graphql/wp-graphql-smart-cache": "^1.0",
     "wpackagist-plugin/pantheon-advanced-page-cache": "*",
     "pantheon-systems/pantheon-decoupled-auth-example": "^1.0",
-    "pantheon-systems/decoupled-preview": "dev-main"
+    "pantheon-systems/decoupled-preview": "dev-main",
+    "wpackagist-plugin/wp-webhooks": "^3.3"
   },
   "license": "GPL-2.0-or-later",
   "authors": [


### PR DESCRIPTION
The bug that I thought we'd have to patch was integrated upstream, so we only needed to add this as a composer dependency.