### PR TITLE
Change decoupled-preview dependency to ^0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,5 @@
       "name": "Brian Perry",
       "email": "brian.perry@pantheon.io"
     }
-  ],
-  "config": {
-    "allow-plugins": {
-      "composer/installers": true
-    }
-  }
+  ]
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "wp-graphql/wp-graphql-smart-cache": "^1.0",
     "wpackagist-plugin/pantheon-advanced-page-cache": "*",
     "pantheon-systems/pantheon-decoupled-auth-example": "^1.0",
-    "pantheon-systems/decoupled-preview": "dev-main",
+    "pantheon-systems/decoupled-preview": "^0.2",
     "wpackagist-plugin/wp-webhooks": "^3.3"
   },
   "license": "GPL-2.0-or-later",
@@ -23,5 +23,10 @@
       "name": "Brian Perry",
       "email": "brian.perry@pantheon.io"
     }
-  ]
+  ],
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true
+    }
+  }
 }


### PR DESCRIPTION
Need to hotfix this due to decoupled-wordpress-composer-managed changing from dev stability unexpectedly.