### PR TITLE
DB-6461: Test Preview Site Action

### DIFF
--- a/pantheon-decoupled.php
+++ b/pantheon-decoupled.php
@@ -44,7 +44,7 @@ function pantheon_decoupled_graphql_smart_object_cache() {
     set_transient( 'graphql_smart_object_cache', true );
 }
 
-function pantheon_decoupled_settings_init() { 
+function pantheon_decoupled_settings_init() {
     add_options_page( 'Pantheon Front-End Sites', 'Pantheon Front-End Sites', 'manage_options', 'pantheon-front-end-sites', 'pantheon_decoupled_settings_page' );
 
     add_settings_field(
@@ -80,11 +80,11 @@ function pantheon_decoupled_resources() {
     ?>
         <div class="wrap">
             <p>
-                <?php esc_html_e( 'Front-End Sites on Pantheon allow you to use', 'wp-pantheon-decoupled' ); ?> 
+                <?php esc_html_e( 'Front-End Sites on Pantheon allow you to use', 'wp-pantheon-decoupled' ); ?>
                 <a href="<?php echo esc_url('https://docs.pantheon.io/guides/decoupled/overview#what-is-a-decoupled-site'); ?>">
                         <?php echo esc_html('decoupled architecture'); ?>
                 </a>
-                <?php esc_html_e( 'to separate your frontend and backend into distinct entities.', 'wp-pantheon-decoupled' ); ?> 
+                <?php esc_html_e( 'to separate your frontend and backend into distinct entities.', 'wp-pantheon-decoupled' ); ?>
             </p>
             <p><?php esc_html_e( 'You can use the WordPress backend starter kit to streamline the creation of your Front-End Site on Pantheon.', 'wp-pantheon-decoupled' ); ?></p>
             <h2><?php esc_html_e( 'Documentation', 'wp-pantheon-decoupled' ); ?></h2>
@@ -126,6 +126,7 @@ function pantheon_decoupled_preview_list_html() {
         require_once WP_PLUGIN_DIR . '/decoupled-preview/src/class-list-table.php';
     }
     require_once plugin_dir_path( __FILE__ ) . 'src/class-list-table.php';
+    add_thickbox();
     $add_site_url = wp_nonce_url(
         add_query_arg( [
             'page' => 'add_preview_sites',

--- a/pantheon-decoupled.php
+++ b/pantheon-decoupled.php
@@ -46,6 +46,14 @@ function pantheon_decoupled_graphql_smart_object_cache() {
 
 function pantheon_decoupled_settings_init() {
     add_options_page( 'Pantheon Front-End Sites', 'Pantheon Front-End Sites', 'manage_options', 'pantheon-front-end-sites', 'pantheon_decoupled_settings_page' );
+    add_submenu_page(
+      'options-general.php',
+      '',
+      '',
+      'manage_options',
+      'test_preview_site',
+      'pantheon_decoupled_test_preview_page'
+    );
 
     add_settings_field(
         'fes-resources',
@@ -148,6 +156,14 @@ function pantheon_decoupled_preview_list_html() {
         ?>
         </div>
     <?php
+}
+
+function pantheon_decoupled_test_preview_page() {
+  ?>
+      <div class="wrap">
+          <h1><?php esc_html_e( 'Test Preview Site', 'wp-pantheon-decoupled' ); ?></h1>
+      </div>
+  <?php
 }
 
 add_action('init', 'pantheon_decoupled_enable_deps');

--- a/pantheon-decoupled.php
+++ b/pantheon-decoupled.php
@@ -166,13 +166,23 @@ function pantheon_decoupled_test_preview_page() {
 
   $docs_link = "<p>Consult the Pantheon Documentation for more information on <a href='https://docs.pantheon.io/guides/decoupled/wp-nextjs-frontend-starters/content-preview' target='_blank' rel='noopener noreferrer'>configuring content preview</a>.</p>\n";
 
-  // Get data for preview site and assemble API call.
+  // Get data for preview site
   $id = isset( $_GET['id'] ) ? absint( sanitize_text_field( $_GET['id'] ) ) : NULL;
   $preview_sites = get_option( 'preview_sites' );
   $preview_site = isset( $preview_sites['preview'][ $id ] ) ? $preview_sites['preview'][ $id ] : NULL;
-  $test_url = $preview_site['url'] . '?secret=' . $preview_site['secret_string'] . '&uri=hello-world&id=1&content_type=post&test=true';
+  $post_type = isset( $preview_site['content_type'] ) ? $preview_site['content_type'][0] : 'post';
+
+  // Get example content to preview.
+  $args = array(
+    'numberposts'	=> 1,
+    'order' => 'ASC',
+    'post_type' => $post_type
+  );
+  $posts = get_posts( $args );
+  $post = $posts[0];
 
   // Make test API call.
+  $test_url = $preview_site['url'] . '?secret=' . $preview_site['secret_string'] . '&uri=' . $post->post_name . '&id=' . $post->ID . '&content_type=' . $post_type . '&test=true';
   $response = wp_remote_get( $test_url );
   $body     = json_decode(wp_remote_retrieve_body( $response ), true);
 
@@ -199,9 +209,9 @@ function pantheon_decoupled_test_preview_page() {
             }
             else if (isset($body["error"])) {
               // We were able to reach the preview endpoint, but there was an error.
-              echo "<p>Error: {$body["error"]}</p>\n";
+              echo "<p>Error: " . esc_html__( $body["error"], 'wp-pantheon-decoupled' ) . "</p>\n";
               if (isset($body["message"]))  {
-                echo "<p>{$body["message"]}</p>\n";
+                echo "<p>Message: " . esc_html__( $body["message"], 'wp-pantheon-decoupled' ) . "</p>\n";
               }
               echo $docs_link;
             }
@@ -210,7 +220,7 @@ function pantheon_decoupled_test_preview_page() {
               echo "<p>WordPress was able to communicate with your preview site and preview example content.</p>\n";
               if (isset($body["message"]))  {
                 echo "<p>Code: {$response['response']['code']}</p>\n";
-                echo "<p>Message: {$body["message"]}</p>\n";
+                echo "<p>Message: " . esc_html__( $body["message"], 'wp-pantheon-decoupled' ) . "</p>\n";
               }
             }
           ?>

--- a/src/class-list-table.php
+++ b/src/class-list-table.php
@@ -29,13 +29,19 @@ class FES_Preview_Table extends List_Table {
 				return isset( $item['content_type'] ) ? ucwords( implode( ', ', $item['content_type'] ) ) : __( 'Post, Page', 'wp-decoupled-preview' );
 			case 'actions':
 				return sprintf(
-					'<a href="%s">%s</a> | <a href="https://example.com?TB_iframe=true&width=600&height=550" class="thickbox">Test</a>',
+					'<a href="%s">%s</a> | <a href="%s&TB_iframe=true&width=600&height=550" class="thickbox">Test</a>',
 					wp_nonce_url( add_query_arg( [
 						'page' => 'add_preview_sites',
 						'action' => 'edit',
 						'id' => $item['id'],
 					], admin_url( 'options-general.php' ) ), 'edit-preview-site', 'nonce' ),
-					esc_html__( 'Edit', 'wp-decoupled-preview' ), 'Test'
+					esc_html__( 'Edit', 'wp-decoupled-preview' ),
+          wp_nonce_url( add_query_arg( [
+						'page' => 'test_preview_site',
+						'action' => 'test',
+						'id' => $item['id'],
+					], admin_url( 'options-general.php' ) ), 'test-preview-site', 'nonce' ),
+          esc_html__( 'Test', 'wp-decoupled-preview' ),
 				);
 			default:
 				return '';

--- a/src/class-list-table.php
+++ b/src/class-list-table.php
@@ -11,5 +11,35 @@
  * List table for displaying the list of sites.
  */
 class FES_Preview_Table extends List_Table {
-	
+  /**
+	 * Render a column value.
+	 *
+	 * @param object $item        The item to render.
+	 * @param string $column_name The column name.
+	 * @return string
+	 */
+	public function column_default( $item, $column_name ) : string {
+		switch ( $column_name ) {
+			case 'label':
+			case 'url':
+			case 'associated_user':
+			case 'preview_type':
+				return isset( $item[ $column_name ] ) ? esc_html( $item[ $column_name ] ) : '';
+			case 'content_type':
+				return isset( $item['content_type'] ) ? ucwords( implode( ', ', $item['content_type'] ) ) : __( 'Post, Page', 'wp-decoupled-preview' );
+			case 'actions':
+				return sprintf(
+					'<a href="%s">%s</a> | <a href="https://example.com?TB_iframe=true&width=600&height=550" class="thickbox">Test</a>',
+					wp_nonce_url( add_query_arg( [
+						'page' => 'add_preview_sites',
+						'action' => 'edit',
+						'id' => $item['id'],
+					], admin_url( 'options-general.php' ) ), 'edit-preview-site', 'nonce' ),
+					esc_html__( 'Edit', 'wp-decoupled-preview' ), 'Test'
+				);
+			default:
+				return '';
+		}
+	}
+
 }

--- a/src/class-list-table.php
+++ b/src/class-list-table.php
@@ -29,7 +29,7 @@ class FES_Preview_Table extends List_Table {
 				return isset( $item['content_type'] ) ? ucwords( implode( ', ', $item['content_type'] ) ) : __( 'Post, Page', 'wp-decoupled-preview' );
 			case 'actions':
 				return sprintf(
-					'<a href="%s">%s</a> | <a href="%s&TB_iframe=true&width=600&height=550" class="thickbox">Test</a>',
+					'<a href="%s">%s</a> | <a href="%s&TB_iframe=true&width=600&height=300" class="thickbox">Test</a>',
 					wp_nonce_url( add_query_arg( [
 						'page' => 'add_preview_sites',
 						'action' => 'edit',


### PR DESCRIPTION
* Added test action to preview sites table in FES settings page.
* Created route to handle test action for a preview site.
* Opened test action in modal on FES settings page.

A few notes:
* This won't currently work in the lando sandbox environment if you're using localhost. Lando's localhost isn't the same as the host machine localhost.
* The test modal could probably use a loading spinner. Couldn't find a quick fix for this, so going to create a follow up ticket.