### PR TITLE
DB-6456: FES Settings Environment Variables Action

### DIFF
--- a/pantheon-decoupled.php
+++ b/pantheon-decoupled.php
@@ -55,6 +55,16 @@ function pantheon_decoupled_settings_init() {
       'pantheon_decoupled_test_preview_page'
     );
 
+    add_submenu_page(
+        'options-general.php',
+        '',
+        '',
+        'manage_options',
+        'env_vars',
+        'pantheon_decoupled_env_vars'
+    );
+  
+
     add_settings_field(
         'fes-resources',
         '',
@@ -226,6 +236,47 @@ function pantheon_decoupled_test_preview_page() {
           ?>
       </div>
   <?php
+}
+
+function pantheon_decoupled_env_vars() {
+    if ( ! current_user_can( 'manage_options' ) ) {
+      wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-decoupled-preview' ) );
+    }
+    check_admin_referer( 'env-vars', 'nonce' );
+
+    // Get data for preview site
+    $id = isset( $_GET['id'] ) ? absint( sanitize_text_field( $_GET['id'] ) ) : NULL;
+    $preview_sites = get_option( 'preview_sites' );
+    $preview_site = isset( $preview_sites['preview'][ $id ] ) ? $preview_sites['preview'][ $id ] : NULL;
+      
+    ?>
+        <style>
+          /* Hide admin bar and padding on top of page. */
+          html.wp-toolbar {
+            padding-top: 0;
+          }
+          #wpadminbar {
+            display: none;
+          }
+        </style>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Environment Variables', 'wp-pantheon-decoupled' ); ?></h1>
+            <h4>PREVIEW_SECRET</h4>
+            <?php
+              echo "<p>Value: {$preview_site['secret_string']}</p>\n";
+            ?>
+            <h4>WP_APPLICATION_USERNAME</h4>
+            <?php
+               echo "<p>Value: {$preview_site['associated_user']}</p>\n";
+            ?>
+            <h4>WP_APPLICATION_PASSWORD</h4>
+            <p>The application password associated with this user intended to be used with this preview site.</p>
+            <h4>Site URL</h4>
+            <?php
+              echo "<p>Link the CMS site that relates to {$preview_site['url']}</p>\n";
+            ?>
+        </div>
+    <?php
 }
 
 add_action('init', 'pantheon_decoupled_enable_deps');

--- a/src/class-list-table.php
+++ b/src/class-list-table.php
@@ -29,19 +29,25 @@ class FES_Preview_Table extends List_Table {
 				return isset( $item['content_type'] ) ? ucwords( implode( ', ', $item['content_type'] ) ) : __( 'Post, Page', 'wp-decoupled-preview' );
 			case 'actions':
 				return sprintf(
-					'<a href="%s">%s</a> | <a href="%s&TB_iframe=true&width=600&height=300" class="thickbox">Test</a>',
+					'<a href="%s">%s</a> | <a href="%s&TB_iframe=true&width=600&height=300" class="thickbox">%s</a> | <a href="%s&TB_iframe=true&width=600&height=300" class="thickbox">%s</a>',
 					wp_nonce_url( add_query_arg( [
 						'page' => 'add_preview_sites',
 						'action' => 'edit',
 						'id' => $item['id'],
 					], admin_url( 'options-general.php' ) ), 'edit-preview-site', 'nonce' ),
 					esc_html__( 'Edit', 'wp-decoupled-preview' ),
-          wp_nonce_url( add_query_arg( [
+					wp_nonce_url( add_query_arg( [
 						'page' => 'test_preview_site',
 						'action' => 'test',
 						'id' => $item['id'],
 					], admin_url( 'options-general.php' ) ), 'test-preview-site', 'nonce' ),
-          esc_html__( 'Test', 'wp-decoupled-preview' ),
+          			esc_html__( 'Test', 'wp-decoupled-preview' ),
+					wp_nonce_url( add_query_arg( [
+						'page' => 'env_vars',
+						'action' => 'env',
+						'id' => $item['id'],
+					], admin_url( 'options-general.php' ) ), 'env-vars', 'nonce' ),
+					esc_html__( 'Environment Variables', 'wp-decoupled-preview' ),
 				);
 			default:
 				return '';


### PR DESCRIPTION
- Added an environment variables action to the preview sites table in the FES settings page.
- This action triggers a modal which displays the `PREVIEW_SECRET` and `WP_APPLICATION_USERNAME` that is associated to the selected preview site. It also displays information on the associated `WP_APPLICATION_PASSWORD`  and the CMS site that should be linked to the front end site.