### PR TITLE
Update the Pantheon WP Coding standards to 2.0 and other related fixes

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -42,12 +42,13 @@
 			<exclude-pattern>pantheon-decoupled.php</exclude-pattern>
 		</exclude>
 	</rule>
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.InvalidPrefixPassed">
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->
 			<property name="prefixes" type="array" value="my-plugin"/>
 		</properties>
 	</rule>
-	<rule ref="WordPress.WP.I18n">
+	<rule ref="WordPress.WP.I18n.TextDomainMismatch">
 		<properties>
 			<!-- Value: replace the text domain used. -->
 			<property name="text_domain" type="array" value="my-plugin"/>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -27,7 +27,7 @@
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
 	<config name="minimum_supported_wp_version" value="4.6"/>
-	<rule ref="WordPress"/>
+	<rule ref="Pantheon-WP"/>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -6,6 +6,7 @@
 	<file>.</file>
 	<exclude-pattern>/vendor/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>
+	<exclude-pattern>/wp-content/</exclude-pattern>
 
 	<!-- How to scan -->
 	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -27,8 +27,21 @@
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
 	<config name="minimum_supported_wp_version" value="4.6"/>
-	<rule ref="Pantheon-WP"/>
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+	<rule ref="Pantheon-WP">
+		<exclude name="Squiz.Commenting.FileComment.Missing">
+			<exclude-pattern>pantheon-decoupled.php</exclude-pattern>
+			<exclude-pattern>pantheon-decoupled-example.php</exclude-pattern>
+		</exclude>
+		<exclude name="WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown">
+			<exclude-pattern>pantheon-decoupled-example.php</exclude-pattern>
+		</exclude>
+		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents">
+			<exclude-pattern>pantheon-decoupled-example.php</exclude-pattern>
+		</exclude>
+		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rules_flush_rules">
+			<exclude-pattern>pantheon-decoupled.php</exclude-pattern>
+		</exclude>
+	</rule>
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->
 			<property name="prefixes" type="array" value="my-plugin"/>

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "pantheon-systems/decoupled-kit-acf": "^1.0"
   },
   "require-dev": {
-    "pantheon-systems/pantheon-wp-coding-standards": "^1.0",
+    "pantheon-systems/pantheon-wp-coding-standards": "^2.0",
     "phpunit/phpunit": "^9.6",
     "yoast/phpunit-polyfills": "^2.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
   },
   "scripts": {
     "lint:php": "find ./pantheon-decoupled-example.php ./pantheon-decoupled.php ./ -name '*.php' -exec php -l {} \\;",
-    "lint:phpcs": "phpcs -s --ignore=tests/* --standard=Pantheon-WP .",
-    "lint:phpcbf": "phpcbf -s --ignore=tests/* --standard=Pantheon-WP .",
+    "lint:phpcs": "phpcs -s --ignore=tests/* .",
+    "lint:phpcbf": "phpcbf -s --ignore=tests/* .",
     "lint": "composer lint:php && composer lint:phpcs",
     "phpunit": "vendor/bin/phpunit",
     "test": "@phpunit",

--- a/composer.json
+++ b/composer.json
@@ -46,5 +46,11 @@
     "phpunit": "vendor/bin/phpunit",
     "test": "@phpunit",
     "test:install": "bash bin/install-wp-tests.sh wordpress_test `whoami` '' localhost latest"
+  },
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/pantheon-decoupled-example.php
+++ b/pantheon-decoupled-example.php
@@ -12,57 +12,58 @@
  * @package         Pantheon_Decoupled_Example
  */
 
-require_once(ABSPATH . 'wp-admin/includes/plugin.php');
-require_once(ABSPATH . 'wp-admin/includes/post.php');
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+require_once ABSPATH . 'wp-admin/includes/post.php';
 
 
 /**
  * Create a post when activating the plugin.
  */
 function pantheon_decoupled_example_create_post() {
-	$image_url = dirname(__FILE__) . '/pizza.jpeg';
+	$image_url = __DIR__ . '/pizza.jpeg';
 	$upload_dir = wp_upload_dir();
-	$image_data = file_get_contents($image_url);
-	$filename = basename($image_url);
-	if (wp_mkdir_p($upload_dir['path'])) {
+	$image_data = file_get_contents( $image_url );
+	$filename = basename( $image_url );
+	if ( wp_mkdir_p( $upload_dir['path'] ) ) {
 		$file = $upload_dir['path'] . '/' . $filename;
 	} else {
 		$file = $upload_dir['basedir'] . '/' . $filename;
 	}
-	file_put_contents($file, $image_data);
-	$wp_filetype = wp_check_filetype($filename, null);
-	$attachment = array(
+	file_put_contents( $file, $image_data );
+	$wp_filetype = wp_check_filetype( $filename, null );
+	$attachment = [
 		'post_mime_type' => $wp_filetype['type'],
-		'post_title' => sanitize_file_name($filename),
+		'post_title' => sanitize_file_name( $filename ),
 		'post_content' => '',
-		'post_status' => 'inherit'
-	);
-	$attach_id = wp_insert_attachment($attachment, $file);
-	require_once(ABSPATH . 'wp-admin/includes/image.php');
-	$attach_data = wp_generate_attachment_metadata($attach_id, $file);
-	wp_update_attachment_metadata($attach_id, $attach_data);
+		'post_status' => 'inherit',
+	];
+	$attach_id = wp_insert_attachment( $attachment, $file );
+	require_once ABSPATH . 'wp-admin/includes/image.php';
+	$attach_data = wp_generate_attachment_metadata( $attach_id, $file );
+	wp_update_attachment_metadata( $attach_id, $attach_data );
 
 	$example_post = [
 		'post_title' => 'Example Post with Image',
-		'post_content' => "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-		'post_status' => 'publish'
+		'post_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+		'post_status' => 'publish',
 	];
-	$post_id = wp_insert_post($example_post);
-	set_post_thumbnail($post_id, $attach_id);
-	set_transient('pantheon_decoupled_example_created', true);
+	$post_id = wp_insert_post( $example_post );
+	set_post_thumbnail( $post_id, $attach_id );
+	set_transient( 'pantheon_decoupled_example_created', true );
 }
 
 /**
  * Create example menu when activating the plugin.
  */
 function pantheon_decoupled_example_menu() {
-	$menu = wp_get_nav_menu_object('Example Menu');
-	$menu_id = $menu ? $menu->term_id : wp_create_nav_menu('Example Menu');
-	wp_update_nav_menu_item($menu_id, 0, array(
-		'menu-item-title' =>  __('Example Post with Image'),
+	$menu = wp_get_nav_menu_object( 'Example Menu' );
+	$menu_id = $menu ? $menu->term_id : wp_create_nav_menu( 'Example Menu' );
+	wp_update_nav_menu_item($menu_id, 0, [
+		'menu-item-title' => __( 'Example Post with Image' ),
 		'menu-item-classes' => 'example_post_with_image',
 		'menu-item-url' => home_url( '/example-post-with-image/' ),
-		'menu-item-status' => 'publish'));
+		'menu-item-status' => 'publish',
+	]);
 	$menu_locations = get_nav_menu_locations();
 	$menu_locations['footer'] = $menu_id;
 	set_theme_mod( 'nav_menu_locations', $menu_locations );
@@ -108,7 +109,7 @@ function delete_default_options() {
  *
  * @return void
  */
-function set_default_options () {
+function set_default_options() {
 	if ( ! get_transient( 'default_preview_set' ) ) {
 		set_transient( 'default_preview_set', true );
 		$secret = wp_generate_password( 10, false );

--- a/pantheon-decoupled-example.php
+++ b/pantheon-decoupled-example.php
@@ -15,7 +15,6 @@
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 require_once ABSPATH . 'wp-admin/includes/post.php';
 
-
 /**
  * Create a post when activating the plugin.
  */

--- a/pantheon-decoupled.php
+++ b/pantheon-decoupled.php
@@ -14,6 +14,9 @@
 
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
+/**
+ * Enable plugins necessary for Decoupled WordPress sites.
+ */
 function pantheon_decoupled_enable_deps() {
 	activate_plugin( 'pantheon-decoupled-auth-example/pantheon-decoupled-auth-example.php' );
 	activate_plugin( 'pantheon-decoupled/pantheon-decoupled-example.php' );
@@ -31,6 +34,9 @@ function pantheon_decoupled_enable_deps() {
 	}
 }
 
+/**
+ * Change permalinks to /%postname%/ when activating the plugin.
+ */
 function pantheon_decoupled_change_permalinks() {
 	global $wp_rewrite;
 	$wp_rewrite->set_permalink_structure( '/%postname%/' );
@@ -39,6 +45,9 @@ function pantheon_decoupled_change_permalinks() {
 	set_transient( 'permalinks_customized', true );
 }
 
+/**
+ * Enable GraphQL Smart Object Cache when activating the plugin.
+ */
 function pantheon_decoupled_graphql_smart_object_cache() {
 	update_option( 'graphql_cache_section', [ 'global_max_age' => 600 ] );
 	set_transient( 'graphql_smart_object_cache', true );

--- a/pantheon-decoupled.php
+++ b/pantheon-decoupled.php
@@ -12,7 +12,7 @@
  * @package         Pantheon_Decoupled
  */
 
-require_once(ABSPATH . 'wp-admin/includes/plugin.php');
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 function pantheon_decoupled_enable_deps() {
 	activate_plugin( 'pantheon-decoupled-auth-example/pantheon-decoupled-auth-example.php' );
@@ -23,20 +23,20 @@ function pantheon_decoupled_enable_deps() {
 	activate_plugin( 'wp-graphql-smart-cache/wp-graphql-smart-cache.php' );
 	activate_plugin( 'wp-gatsby/wp-gatsby.php' );
 	activate_plugin( 'wp-force-login/wp-force-login.php' );
-	if ( !get_transient('permalinks_customized') ) {
+	if ( ! get_transient( 'permalinks_customized' ) ) {
 		pantheon_decoupled_change_permalinks();
 	}
-	if ( !get_transient( 'graphql_smart_object_cache' ) ) {
+	if ( ! get_transient( 'graphql_smart_object_cache' ) ) {
 		pantheon_decoupled_graphql_smart_object_cache();
 	}
 }
 
 function pantheon_decoupled_change_permalinks() {
 	global $wp_rewrite;
-	$wp_rewrite->set_permalink_structure('/%postname%/');
-	update_option( "rewrite_rules", FALSE );
+	$wp_rewrite->set_permalink_structure( '/%postname%/' );
+	update_option( 'rewrite_rules', false );
 	$wp_rewrite->flush_rules( true );
-	set_transient('permalinks_customized', true);
+	set_transient( 'permalinks_customized', true );
 }
 
 function pantheon_decoupled_graphql_smart_object_cache() {
@@ -44,4 +44,4 @@ function pantheon_decoupled_graphql_smart_object_cache() {
 	set_transient( 'graphql_smart_object_cache', true );
 }
 
-add_action('init', 'pantheon_decoupled_enable_deps');
+add_action( 'init', 'pantheon_decoupled_enable_deps' );


### PR DESCRIPTION
This PR does a couple of things:

1. Bumps Pantheon-WP-Coding-Standards to 2.0
2. Removes the `--standard` from the `composer:phpcs` rule so we can use the ruleset in `.phpcs.xml.dist` and manually tweak the rules
3. Manually tweaks said rules; makes some adjustments for WPCS 3.0, excludes the `wp-content` directory from linting, and ignores several specific sniffs for this codebase.
4. Applies all the PHPCS fixes so it passes lint tests.