### PR TITLE
DB-6734: Add Preview Site in Modal

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,13 @@
+name: Lint
+on: push
+jobs:
+  lint:
+    name: Pantheon WP Coding Standards
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Lint
+        run: |
+          composer install
+          composer lint:phpcs

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -6,6 +6,7 @@
 	<file>.</file>
 	<exclude-pattern>/vendor/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>
+	<exclude-pattern>/wp-content/</exclude-pattern>
 
 	<!-- How to scan -->
 	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
@@ -26,14 +27,28 @@
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
 	<config name="minimum_supported_wp_version" value="4.6"/>
-	<rule ref="WordPress"/>
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+	<rule ref="Pantheon-WP">
+		<exclude name="Squiz.Commenting.FileComment.Missing">
+			<exclude-pattern>pantheon-decoupled.php</exclude-pattern>
+			<exclude-pattern>pantheon-decoupled-example.php</exclude-pattern>
+		</exclude>
+		<exclude name="WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown">
+			<exclude-pattern>pantheon-decoupled-example.php</exclude-pattern>
+		</exclude>
+		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents">
+			<exclude-pattern>pantheon-decoupled-example.php</exclude-pattern>
+		</exclude>
+		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rules_flush_rules">
+			<exclude-pattern>pantheon-decoupled.php</exclude-pattern>
+		</exclude>
+	</rule>
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.InvalidPrefixPassed">
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->
 			<property name="prefixes" type="array" value="my-plugin"/>
 		</properties>
 	</rule>
-	<rule ref="WordPress.WP.I18n">
+	<rule ref="WordPress.WP.I18n.TextDomainMismatch">
 		<properties>
 			<!-- Value: replace the text domain used. -->
 			<property name="text_domain" type="array" value="my-plugin"/>

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "pantheon-systems/decoupled-kit-acf": "^1.0"
   },
   "require-dev": {
-    "pantheon-systems/pantheon-wp-coding-standards": "^1.0",
+    "pantheon-systems/pantheon-wp-coding-standards": "^2.0",
     "phpunit/phpunit": "^9.6",
     "yoast/phpunit-polyfills": "^2.0"
   },
@@ -40,11 +40,17 @@
   },
   "scripts": {
     "lint:php": "find ./pantheon-decoupled-example.php ./pantheon-decoupled.php ./ -name '*.php' -exec php -l {} \\;",
-    "lint:phpcs": "phpcs -s --ignore=tests/* --standard=Pantheon-WP .",
-    "lint:phpcbf": "phpcbf -s --ignore=tests/* --standard=Pantheon-WP .",
+    "lint:phpcs": "phpcs -s --ignore=tests/* .",
+    "lint:phpcbf": "phpcbf -s --ignore=tests/* .",
     "lint": "composer lint:php && composer lint:phpcs",
     "phpunit": "vendor/bin/phpunit",
     "test": "@phpunit",
     "test:install": "bash bin/install-wp-tests.sh wordpress_test `whoami` '' localhost latest"
+  },
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     }
   },
   "scripts": {
-    "lint:php": "find ./pantheon-decoupled-example.php ./pantheon-decoupled.php ./ -name '*.php' -exec php -l {} \\;",
+    "lint:php": "find ./pantheon-decoupled-example.php ./pantheon-decoupled.php ./src -name '*.php' -exec php -l {} \\;",
     "lint:phpcs": "phpcs -s --ignore=tests/* .",
     "lint:phpcbf": "phpcbf -s --ignore=tests/* .",
     "lint": "composer lint:php && composer lint:phpcs",

--- a/pantheon-decoupled-example.php
+++ b/pantheon-decoupled-example.php
@@ -12,57 +12,57 @@
  * @package         Pantheon_Decoupled_Example
  */
 
-require_once(ABSPATH . 'wp-admin/includes/plugin.php');
-require_once(ABSPATH . 'wp-admin/includes/post.php');
-
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+require_once ABSPATH . 'wp-admin/includes/post.php';
 
 /**
  * Create a post when activating the plugin.
  */
 function pantheon_decoupled_example_create_post() {
-	$image_url = dirname(__FILE__) . '/pizza.jpeg';
+	$image_url = __DIR__ . '/pizza.jpeg';
 	$upload_dir = wp_upload_dir();
-	$image_data = file_get_contents($image_url);
-	$filename = basename($image_url);
-	if (wp_mkdir_p($upload_dir['path'])) {
+	$image_data = file_get_contents( $image_url );
+	$filename = basename( $image_url );
+	if ( wp_mkdir_p( $upload_dir['path'] ) ) {
 		$file = $upload_dir['path'] . '/' . $filename;
 	} else {
 		$file = $upload_dir['basedir'] . '/' . $filename;
 	}
-	file_put_contents($file, $image_data);
-	$wp_filetype = wp_check_filetype($filename, null);
-	$attachment = array(
+	file_put_contents( $file, $image_data );
+	$wp_filetype = wp_check_filetype( $filename, null );
+	$attachment = [
 		'post_mime_type' => $wp_filetype['type'],
-		'post_title' => sanitize_file_name($filename),
+		'post_title' => sanitize_file_name( $filename ),
 		'post_content' => '',
-		'post_status' => 'inherit'
-	);
-	$attach_id = wp_insert_attachment($attachment, $file);
-	require_once(ABSPATH . 'wp-admin/includes/image.php');
-	$attach_data = wp_generate_attachment_metadata($attach_id, $file);
-	wp_update_attachment_metadata($attach_id, $attach_data);
+		'post_status' => 'inherit',
+	];
+	$attach_id = wp_insert_attachment( $attachment, $file );
+	require_once ABSPATH . 'wp-admin/includes/image.php';
+	$attach_data = wp_generate_attachment_metadata( $attach_id, $file );
+	wp_update_attachment_metadata( $attach_id, $attach_data );
 
 	$example_post = [
 		'post_title' => 'Example Post with Image',
-		'post_content' => "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-		'post_status' => 'publish'
+		'post_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+		'post_status' => 'publish',
 	];
-	$post_id = wp_insert_post($example_post);
-	set_post_thumbnail($post_id, $attach_id);
-	set_transient('pantheon_decoupled_example_created', true);
+	$post_id = wp_insert_post( $example_post );
+	set_post_thumbnail( $post_id, $attach_id );
+	set_transient( 'pantheon_decoupled_example_created', true );
 }
 
 /**
  * Create example menu when activating the plugin.
  */
 function pantheon_decoupled_example_menu() {
-	$menu = wp_get_nav_menu_object('Example Menu');
-	$menu_id = $menu ? $menu->term_id : wp_create_nav_menu('Example Menu');
-	wp_update_nav_menu_item($menu_id, 0, array(
-		'menu-item-title' =>  __('Example Post with Image'),
+	$menu = wp_get_nav_menu_object( 'Example Menu' );
+	$menu_id = $menu ? $menu->term_id : wp_create_nav_menu( 'Example Menu' );
+	wp_update_nav_menu_item($menu_id, 0, [
+		'menu-item-title' => __( 'Example Post with Image' ),
 		'menu-item-classes' => 'example_post_with_image',
 		'menu-item-url' => home_url( '/example-post-with-image/' ),
-		'menu-item-status' => 'publish'));
+		'menu-item-status' => 'publish',
+	]);
 	$menu_locations = get_nav_menu_locations();
 	$menu_locations['footer'] = $menu_id;
 	set_theme_mod( 'nav_menu_locations', $menu_locations );
@@ -83,7 +83,7 @@ function delete_default_options() {
  *
  * @return void
  */
-function set_default_options () {
+function set_default_options() {
 	if ( ! get_transient( 'default_preview_set' ) ) {
 		set_transient( 'default_preview_set', true );
 		$secret = wp_generate_password( 10, false );

--- a/pantheon-decoupled.php
+++ b/pantheon-decoupled.php
@@ -12,33 +12,42 @@
  * @package         Pantheon_Decoupled
  */
 
-require_once(ABSPATH . 'wp-admin/includes/plugin.php');
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
+/**
+ * Enable plugins necessary for Decoupled WordPress sites.
+ */
 function pantheon_decoupled_enable_deps() {
-    activate_plugin( 'pantheon-decoupled-auth-example/pantheon-decoupled-auth-example.php' );
-    activate_plugin( 'pantheon-decoupled/pantheon-decoupled-example.php' );
-    activate_plugin( 'decoupled-preview/wp-decoupled-preview.php' );
-    activate_plugin( 'pantheon-advanced-page-cache/pantheon-advanced-page-cache.php' );
-    activate_plugin( 'wp-graphql/wp-graphql.php' );
-    activate_plugin( 'wp-graphql-smart-cache/wp-graphql-smart-cache.php' );
-    activate_plugin( 'wp-gatsby/wp-gatsby.php' );
-    activate_plugin( 'wp-force-login/wp-force-login.php' );
-    if ( !get_transient('permalinks_customized') ) {
-        pantheon_decoupled_change_permalinks();
-    }
-    if ( !get_transient( 'graphql_smart_object_cache' ) ) {
-        pantheon_decoupled_graphql_smart_object_cache();
-    }
+	activate_plugin( 'pantheon-decoupled-auth-example/pantheon-decoupled-auth-example.php' );
+	activate_plugin( 'pantheon-decoupled/pantheon-decoupled-example.php' );
+	activate_plugin( 'decoupled-preview/wp-decoupled-preview.php' );
+	activate_plugin( 'pantheon-advanced-page-cache/pantheon-advanced-page-cache.php' );
+	activate_plugin( 'wp-graphql/wp-graphql.php' );
+	activate_plugin( 'wp-graphql-smart-cache/wp-graphql-smart-cache.php' );
+	activate_plugin( 'wp-gatsby/wp-gatsby.php' );
+	activate_plugin( 'wp-force-login/wp-force-login.php' );
+	if ( ! get_transient( 'permalinks_customized' ) ) {
+		pantheon_decoupled_change_permalinks();
+	}
+	if ( ! get_transient( 'graphql_smart_object_cache' ) ) {
+		pantheon_decoupled_graphql_smart_object_cache();
+	}
 }
 
+/**
+ * Change permalinks to /%postname%/ when activating the plugin.
+ */
 function pantheon_decoupled_change_permalinks() {
-    global $wp_rewrite;
-    $wp_rewrite->set_permalink_structure('/%postname%/');
-    update_option( "rewrite_rules", FALSE );
-    $wp_rewrite->flush_rules( true );
-    set_transient('permalinks_customized', true);
+	global $wp_rewrite;
+	$wp_rewrite->set_permalink_structure( '/%postname%/' );
+	update_option( 'rewrite_rules', false );
+	$wp_rewrite->flush_rules( true );
+	set_transient( 'permalinks_customized', true );
 }
 
+/**
+ * Enable GraphQL Smart Object Cache when activating the plugin.
+ */
 function pantheon_decoupled_graphql_smart_object_cache() {
     update_option( 'graphql_cache_section', [ 'global_max_age' => 600 ] );
     set_transient( 'graphql_smart_object_cache', true );
@@ -63,7 +72,7 @@ function pantheon_decoupled_settings_init() {
         'env_vars',
         'pantheon_decoupled_env_vars'
     );
-  
+
 
     add_settings_field(
         'fes-resources',
@@ -248,10 +257,10 @@ function pantheon_decoupled_env_vars() {
     $id = isset( $_GET['id'] ) ? absint( sanitize_text_field( $_GET['id'] ) ) : NULL;
     $preview_sites = get_option( 'preview_sites' );
     $preview_site = isset( $preview_sites['preview'][ $id ] ) ? $preview_sites['preview'][ $id ] : NULL;
-    
+
     global $wp;
     $home_url = home_url( $wp->request );
-      
+
     ?>
         <style>
           /* Hide admin bar and padding on top of page. */

--- a/pantheon-decoupled.php
+++ b/pantheon-decoupled.php
@@ -214,17 +214,9 @@ function pantheon_decoupled_create_html() {
     #TB_window #wpcontent {
       margin-left: 0;
     }
-    /*
-    Remove back to preview sites link which does't make sense in this
-    context
-    */
-    #TB_window h1 + p a {
-      display: none;
-    }
   </style>
   <div class="wrap">
 				<h1><?php esc_html_e( 'Create or Edit Preview Site', 'wp-decoupled-preview' ); ?></h1>
-				<p><a href="<?php echo esc_url( add_query_arg( 'page', 'preview_sites', admin_url( 'options-general.php' ) ) ); ?>">&larr; <?php esc_html_e( 'Back to Preview Sites Configuration', 'wp-decoupled-preview' ); ?></a></p>
 				<form action="<?php echo esc_url( $action ); ?>" method="post">
 					<?php
           settings_fields( 'wp-decoupled-preview' );

--- a/pantheon-decoupled.php
+++ b/pantheon-decoupled.php
@@ -73,6 +73,15 @@ function pantheon_decoupled_settings_init() {
         'pantheon_decoupled_env_vars'
     );
 
+    add_submenu_page(
+      NULL,
+      '',
+      '',
+      'manage_options',
+      'fes_add_preview_sites',
+      'pantheon_decoupled_create_html',
+    );
+
 
     add_settings_field(
         'fes-resources',
@@ -156,7 +165,7 @@ function pantheon_decoupled_preview_list_html() {
     add_thickbox();
     $add_site_url = wp_nonce_url(
         add_query_arg( [
-            'page' => 'add_preview_sites',
+            'page' => 'fes_add_preview_sites',
         ], admin_url( 'options-general.php' ) ),
         'edit-preview-site',
         'nonce'
@@ -164,7 +173,7 @@ function pantheon_decoupled_preview_list_html() {
     ?>
 		<h2><?php esc_html_e( 'Preview Sites', 'wp-pantheon-decoupled' ); ?></h2>
         <span>
-            <a href="<?php echo esc_url_raw( $add_site_url ); ?>" class="button-primary">+ <?php esc_html_e( 'Add Preview Site', 'wp-pantheon-decoupled-list' ); ?></a>
+            <a href="<?php echo esc_url_raw( $add_site_url ); ?>&width=600&height=500" class="button-primary thickbox">+ <?php esc_html_e( 'Add Preview Site', 'wp-pantheon-decoupled-list' ); ?></a>
         </span>
         <div>
         <?php
@@ -175,6 +184,71 @@ function pantheon_decoupled_preview_list_html() {
         ?>
         </div>
     <?php
+}
+
+function pantheon_decoupled_create_html() {
+  if ( ! current_user_can( 'manage_options' ) ) {
+    wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-decoupled-preview' ) );
+  }
+
+  check_admin_referer( 'edit-preview-site', 'nonce' );
+  $edit_id = isset( $_GET['id'] ) ? sanitize_text_field( $_GET['id'] ) : false;
+  if ( $edit_id ) {
+    $action = 'options.php?edit=' . $edit_id;
+  } else {
+    $action = 'options.php';
+  }
+  ?>
+  <style>
+    /*
+    Styles here are for ajax version of thickbox. We lose some styles, but gain
+    a loading indicator...
+    */
+    #TB_window #adminmenumain {
+      display: none;
+    }
+    #TB_window #wpcontent,
+    #TB_window #wpfooter {
+      margin-left: 0;
+    }
+  </style>
+  <h1>FES Add Preview</h1>
+  <div class="wrap">
+				<h1><?php esc_html_e( 'Create or Edit Preview Site', 'wp-decoupled-preview' ); ?></h1>
+				<p><a href="<?php echo esc_url( add_query_arg( 'page', 'preview_sites', admin_url( 'options-general.php' ) ) ); ?>">&larr; <?php esc_html_e( 'Back to Preview Sites Configuration', 'wp-decoupled-preview' ); ?></a></p>
+				<form action="<?php echo esc_url( $action ); ?>" method="post">
+					<?php
+          settings_fields( 'wp-decoupled-preview' );
+          do_settings_sections( 'preview_sites' );
+					?>
+					<?php wp_nonce_field( 'edit-preview-site', 'nonce' ); ?>
+					<?php submit_button(); ?>
+					<?php
+					if ( $edit_id ) {
+						$site_label = $this->get_preview_site( $edit_id )['label'];
+						$url = wp_nonce_url(
+							add_query_arg( [
+								'page' => 'delete_preview_site',
+								'id' => $edit_id,
+							], admin_url( 'options-general.php' ) ),
+							'edit-preview-site',
+							'nonce'
+						);
+						?>
+						<a id="delete-preview" class="button-secondary button-large" href="<?php echo esc_url( $url ); ?>">
+							<?php
+							echo esc_html(
+								// Translators: %s is the preview site label.
+								sprintf( __( 'Delete %s', 'wp-decoupled-preview' ), $site_label )
+							);
+							?>
+						</a>
+						<?php
+					}
+					?>
+				</form>
+			</div>
+  <?php
 }
 
 function pantheon_decoupled_test_preview_page() {

--- a/pantheon-decoupled.php
+++ b/pantheon-decoupled.php
@@ -49,106 +49,121 @@ function pantheon_decoupled_change_permalinks() {
  * Enable GraphQL Smart Object Cache when activating the plugin.
  */
 function pantheon_decoupled_graphql_smart_object_cache() {
-    update_option( 'graphql_cache_section', [ 'global_max_age' => 600 ] );
-    set_transient( 'graphql_smart_object_cache', true );
+	update_option( 'graphql_cache_section', [ 'global_max_age' => 600 ] );
+	set_transient( 'graphql_smart_object_cache', true );
 }
 
+/**
+ * Initialize settings pages.
+ *
+ * @return void
+ */
 function pantheon_decoupled_settings_init() {
-    add_options_page( 'Pantheon Front-End Sites', 'Pantheon Front-End Sites', 'manage_options', 'pantheon-front-end-sites', 'pantheon_decoupled_settings_page' );
-    add_submenu_page(
-      NULL,
-      '',
-      '',
-      'manage_options',
-      'test_preview_site',
-      'pantheon_decoupled_test_preview_page',
-    );
+	add_options_page( 'Pantheon Front-End Sites', 'Pantheon Front-End Sites', 'manage_options', 'pantheon-front-end-sites', 'pantheon_decoupled_settings_page' );
+	add_submenu_page(
+		null,
+		'',
+		'',
+		'manage_options',
+		'test_preview_site',
+		'pantheon_decoupled_test_preview_page'
+	);
 
-    add_submenu_page(
-        NULL,
-        '',
-        '',
-        'manage_options',
-        'env_vars',
-        'pantheon_decoupled_env_vars'
-    );
+	add_submenu_page(
+		null,
+		'',
+		'',
+		'manage_options',
+		'env_vars',
+		'pantheon_decoupled_env_vars'
+	);
 
-    add_submenu_page(
-      NULL,
-      '',
-      '',
-      'manage_options',
-      'fes_add_preview_sites',
-      'pantheon_decoupled_create_html',
-    );
+	add_submenu_page(
+		null,
+		'',
+		'',
+		'manage_options',
+		'fes_add_preview_sites',
+		'pantheon_decoupled_create_html'
+	);
 
 
-    add_settings_field(
-        'fes-resources',
-        '',
-        'pantheon_decoupled_resources',
-        'pantheon-front-end-sites',
-        'wp-pantheon-decoupled-resources'
-    );
+	add_settings_field(
+		'fes-resources',
+		'',
+		'pantheon_decoupled_resources',
+		'pantheon-front-end-sites',
+		'wp-pantheon-decoupled-resources'
+	);
 
-    add_settings_field(
-     'preview_list',
-     '',
-     'pantheon_decoupled_preview_list_html',
-     'pantheon-front-end-sites',
-     'wp-pantheon-decoupled-list'
-    );
+	add_settings_field(
+		'preview_list',
+		'',
+		'pantheon_decoupled_preview_list_html',
+		'pantheon-front-end-sites',
+		'wp-pantheon-decoupled-list'
+	);
 }
 
+/**
+ * Render markup for front-end sites settings page
+ *
+ * @return void
+ */
 function pantheon_decoupled_settings_page() {
-    ?>
-        <div class="wrap">
-            <h1><?php esc_html_e( 'Pantheon Front-End Sites', 'wp-pantheon-decoupled' ); ?></h1>
-            <?php
-				        do_settings_fields( 'pantheon-front-end-sites', 'wp-pantheon-decoupled-resources' );
-                do_settings_fields( 'pantheon-front-end-sites', 'wp-pantheon-decoupled-list' );
-            ?>
-        </div>
-    <?php
+	?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Pantheon Front-End Sites', 'wp-pantheon-decoupled' ); ?></h1>
+			<?php
+						do_settings_fields( 'pantheon-front-end-sites', 'wp-pantheon-decoupled-resources' );
+				do_settings_fields( 'pantheon-front-end-sites', 'wp-pantheon-decoupled-list' );
+			?>
+		</div>
+	<?php
 }
 
+/**
+ * Render documentation and resources for front-end sites settings page
+ *
+ * @return void
+ */
 function pantheon_decoupled_resources() {
-    ?>
-        <div class="wrap">
-            <p>
-                <?php esc_html_e( 'Front-End Sites on Pantheon allow you to use', 'wp-pantheon-decoupled' ); ?>
-                <a href="<?php echo esc_url('https://docs.pantheon.io/guides/decoupled/overview#what-is-a-decoupled-site'); ?>">
-                        <?php echo esc_html('decoupled architecture'); ?>
-                </a>
-                <?php esc_html_e( 'to separate your frontend and backend into distinct entities.', 'wp-pantheon-decoupled' ); ?>
-            </p>
-            <p><?php esc_html_e( 'You can use the WordPress backend starter kit to streamline the creation of your Front-End Site on Pantheon.', 'wp-pantheon-decoupled' ); ?></p>
-            <h2><?php esc_html_e( 'Documentation', 'wp-pantheon-decoupled' ); ?></h2>
+	?>
+		<div class="wrap">
+			<p>
+				<?php esc_html_e( 'Front-End Sites on Pantheon allow you to use', 'wp-pantheon-decoupled' ); ?>
+				<a href="<?php echo esc_url( 'https://docs.pantheon.io/guides/decoupled/overview#what-is-a-decoupled-site' ); ?>">
+						<?php echo esc_html( 'decoupled architecture' ); ?>
+				</a>
+				<?php esc_html_e( 'to separate your frontend and backend into distinct entities.', 'wp-pantheon-decoupled' ); ?>
+			</p>
+			<p><?php esc_html_e( 'You can use the WordPress backend starter kit to streamline the creation of your Front-End Site on Pantheon.', 'wp-pantheon-decoupled' ); ?></p>
+			<h2><?php esc_html_e( 'Documentation', 'wp-pantheon-decoupled' ); ?></h2>
 
-            <ul style="list-style-type:disc">
-                <li>
-                    <a href="<?php echo esc_url('https://docs.pantheon.io/guides/decoupled/overview'); ?>">
-                        <?php echo esc_html('Front-End Sites Overview');?>
-                    </a>
-                </li>
-                <li>
-                    <a href="<?php echo esc_url('https://docs.pantheon.io/guides/decoupled/wp-backend-starters'); ?>">
-                        <?php echo esc_html('WordPress Backend Starters'); ?>
-                    </a>
-                </li>
-                <li>
-                    <a href="<?php echo esc_url('https://docs.pantheon.io/guides/decoupled/wp-nextjs-frontend-starters'); ?>">
-                        <?php echo esc_html('WordPress + Next.js Frontend Starter'); ?>
-                    </a>
-                </li>
-                <li>
-                    <a href="<?php echo esc_url('https://docs.pantheon.io/guides/decoupled/wp-gatsby-frontend-starters'); ?>">
-                        <?php echo esc_html('WordPress + Gatsby Frontend Starter'); ?>
-                    </a>
-                </li>
-            </ul>
-        </div>
-    <?php
+			<ul style="list-style-type:disc">
+				<li>
+					<a href="<?php echo esc_url( 'https://docs.pantheon.io/guides/decoupled/overview' ); ?>">
+						<?php echo esc_html( 'Front-End Sites Overview' ); ?>
+					</a>
+				</li>
+				<li>
+					<a href="<?php echo esc_url( 'https://docs.pantheon.io/guides/decoupled/wp-backend-starters' ); ?>">
+						<?php echo esc_html( 'WordPress Backend Starters' ); ?>
+					</a>
+				</li>
+				<li>
+					<a href="<?php echo esc_url( 'https://docs.pantheon.io/guides/decoupled/wp-nextjs-frontend-starters' ); ?>">
+						<?php echo esc_html( 'WordPress + Next.js Frontend Starter' ); ?>
+					</a>
+				</li>
+				<li>
+					<a href="<?php echo esc_url( 'https://docs.pantheon.io/guides/decoupled/wp-gatsby-frontend-starters' ); ?>">
+						<?php echo esc_html( 'WordPress + Gatsby Frontend Starter' ); ?>
+					</a>
+				</li>
+			</ul>
+		</div>
+	<?php
 }
 
 /**
@@ -157,250 +172,283 @@ function pantheon_decoupled_resources() {
  * @return void
  */
 function pantheon_decoupled_preview_list_html() {
-    // Check if the List_Table class is available.
-    if ( ! class_exists( 'List_Table' ) ) {
-        require_once WP_PLUGIN_DIR . '/decoupled-preview/src/class-list-table.php';
-    }
-    require_once plugin_dir_path( __FILE__ ) . 'src/class-list-table.php';
-    add_thickbox();
-    $add_site_url = wp_nonce_url(
-        add_query_arg( [
-            'page' => 'fes_add_preview_sites',
-        ], admin_url( 'options-general.php' ) ),
-        'edit-preview-site',
-        'nonce'
-    );
-    ?>
+	// Check if the List_Table class is available.
+	if ( ! class_exists( 'List_Table' ) ) {
+		require_once WP_PLUGIN_DIR . '/decoupled-preview/src/class-list-table.php';
+	}
+	require_once plugin_dir_path( __FILE__ ) . 'src/class-fes-preview-table.php';
+	add_thickbox();
+	$add_site_url = wp_nonce_url(
+		add_query_arg( [
+			'page' => 'fes_add_preview_sites',
+		], admin_url( 'options-general.php' ) ),
+		'edit-preview-site',
+		'nonce'
+	);
+	?>
 		<h2><?php esc_html_e( 'Preview Sites', 'wp-pantheon-decoupled' ); ?></h2>
-        <span>
-            <a href="<?php echo esc_url_raw( $add_site_url ); ?>&width=600&height=500" class="button-primary thickbox">+ <?php esc_html_e( 'Add Preview Site', 'wp-pantheon-decoupled-list' ); ?></a>
-        </span>
-        <div>
-        <?php
-        wp_create_nonce( 'preview-site-list' );
-        $wp_list_table = new FES_Preview_Table();
-        $wp_list_table-> prepare_items();
-        $wp_list_table->display();
-        ?>
-        </div>
-    <?php
+		<span>
+			<a href="<?php echo esc_url_raw( $add_site_url ); ?>&width=600&height=500" class="button-primary thickbox">+ <?php esc_html_e( 'Add Preview Site', 'wp-pantheon-decoupled-list' ); ?></a>
+		</span>
+		<div>
+		<?php
+		wp_create_nonce( 'preview-site-list' );
+		$wp_list_table = new FES_Preview_Table();
+		$wp_list_table->prepare_items();
+		$wp_list_table->display();
+		?>
+		</div>
+	<?php
 }
 
+/**
+ * Render markup for front-end sites specific create preview site form.
+ *
+ * @return void
+ */
 function pantheon_decoupled_create_html() {
-  if ( ! current_user_can( 'manage_options' ) ) {
-    wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-decoupled-preview' ) );
-  }
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-decoupled-preview' ) );
+	}
 
-  check_admin_referer( 'edit-preview-site', 'nonce' );
-  $edit_id = isset( $_GET['id'] ) ? sanitize_text_field( $_GET['id'] ) : false;
-  if ( $edit_id ) {
-    $action = 'options.php?fes=1&edit=' . $edit_id;
-  } else {
-    $action = 'options.php?fes=1';
-  }
-  ?>
-  <style>
-    /*
-    Styles here are for ajax version of thickbox. We lose some styles, but gain
-    a loading indicator...
-    */
-    #TB_window {
-      background-color: rgb(240, 240, 241);
-    }
-    #TB_window #adminmenumain,
-    #TB_window #wpfooter {
-      display: none;
-    }
-    #TB_window #wpcontent {
-      margin-left: 0;
-    }
-  </style>
-  <div class="wrap">
+	check_admin_referer( 'edit-preview-site', 'nonce' );
+	$edit_id = isset( $_GET['id'] ) ? sanitize_text_field( $_GET['id'] ) : false;
+	if ( $edit_id ) {
+		$action = 'options.php?fes=1&edit=' . $edit_id;
+	} else {
+		$action = 'options.php?fes=1';
+	}
+	?>
+	<style>
+	/*
+	Styles here are for ajax version of thickbox. We lose some styles, but gain
+	a loading indicator...
+	*/
+	#TB_window {
+		background-color: rgb(240, 240, 241);
+	}
+	#TB_window #adminmenumain,
+	#TB_window #wpfooter {
+		display: none;
+	}
+	#TB_window #wpcontent {
+		margin-left: 0;
+	}
+	</style>
+	<div class="wrap">
 				<h1><?php esc_html_e( 'Create or Edit Preview Site', 'wp-decoupled-preview' ); ?></h1>
 				<form action="<?php echo esc_url( $action ); ?>" method="post">
 					<?php
-          settings_fields( 'wp-decoupled-preview' );
-          do_settings_sections( 'preview_sites' );
+					settings_fields( 'wp-decoupled-preview' );
+					do_settings_sections( 'preview_sites' );
 					?>
 					<?php wp_nonce_field( 'edit-preview-site', 'nonce' ); ?>
 					<?php submit_button(); ?>
-					<?php
-					if ( $edit_id ) {
-						$site_label = $this->get_preview_site( $edit_id )['label'];
-						$url = wp_nonce_url(
-							add_query_arg( [
-								'page' => 'delete_preview_site',
-								'id' => $edit_id,
-							], admin_url( 'options-general.php' ) ),
-							'edit-preview-site',
-							'nonce'
-						);
-						?>
-						<a id="delete-preview" class="button-secondary button-large" href="<?php echo esc_url( $url ); ?>">
-							<?php
-							echo esc_html(
-								// Translators: %s is the preview site label.
-								sprintf( __( 'Delete %s', 'wp-decoupled-preview' ), $site_label )
-							);
-							?>
-						</a>
-						<?php
-					}
-					?>
 				</form>
 			</div>
-  <?php
+	<?php
 }
 
+/**
+ * Render test preview site modal.
+ *
+ * @return void
+ */
 function pantheon_decoupled_test_preview_page() {
-  if ( ! current_user_can( 'manage_options' ) ) {
-    wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-decoupled-preview' ) );
-  }
-  check_admin_referer( 'test-preview-site', 'nonce' );
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-decoupled-preview' ) );
+	}
+	check_admin_referer( 'test-preview-site', 'nonce' );
 
-  $docs_link = "<p>Consult the Pantheon Documentation for more information on <a href='https://docs.pantheon.io/guides/decoupled/wp-nextjs-frontend-starters/content-preview' target='_blank' rel='noopener noreferrer'>configuring content preview</a>.</p>\n";
+	// Get data for preview site.
+	$id = isset( $_GET['id'] ) ? absint( sanitize_text_field( $_GET['id'] ) ) : null;
+	$preview_sites = get_option( 'preview_sites' );
+	$preview_site = isset( $preview_sites['preview'][ $id ] ) ? $preview_sites['preview'][ $id ] : null;
+	$post_type = isset( $preview_site['content_type'] ) ? $preview_site['content_type'][0] : 'post';
 
-  // Get data for preview site
-  $id = isset( $_GET['id'] ) ? absint( sanitize_text_field( $_GET['id'] ) ) : NULL;
-  $preview_sites = get_option( 'preview_sites' );
-  $preview_site = isset( $preview_sites['preview'][ $id ] ) ? $preview_sites['preview'][ $id ] : NULL;
-  $post_type = isset( $preview_site['content_type'] ) ? $preview_site['content_type'][0] : 'post';
+	// Get example content to preview.
+	$args = [
+		'numberposts'   => 1,
+		'order' => 'ASC',
+		'post_type' => $post_type,
+		'suppress_filters' => false,
+	];
+  // phpcs:disable WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
+	$posts = get_posts( $args );
+	$post = $posts[0];
 
-  // Get example content to preview.
-  $args = array(
-    'numberposts'	=> 1,
-    'order' => 'ASC',
-    'post_type' => $post_type
-  );
-  $posts = get_posts( $args );
-  $post = $posts[0];
-
-  // Make test API call.
-  $test_url = $preview_site['url'] . '?secret=' . $preview_site['secret_string'] . '&uri=' . $post->post_name . '&id=' . $post->ID . '&content_type=' . $post_type . '&test=true';
-  $response = wp_remote_get( $test_url );
-  $body     = json_decode(wp_remote_retrieve_body( $response ), true);
-
-  ?>
-      <style>
-        /* Hide admin bar and padding on top of page. */
-        html.wp-toolbar {
-          padding-top: 0;
-        }
-        #wpadminbar {
-          display: none;
-        }
-      </style>
-      <div class="wrap">
-          <h1><?php esc_html_e( 'Test Preview Site', 'wp-pantheon-decoupled' ); ?></h1>
-          <?php
-            echo "<h3>{$preview_site['label']}</h3>\n";
-            if (empty($body)) {
-              // We weren't able to reach the preview endpoint at all.
-              echo "<p>There was an error connecting to the preview site.</p>\n";
-              echo "<p>Code: {$response['response']['code']}</p>\n";
-              echo "<p>Message: {$response['response']['message']}</p>\n";
-              echo $docs_link;
-            }
-            else if (isset($body["error"])) {
-              // We were able to reach the preview endpoint, but there was an error.
-              echo "<p>Error: " . esc_html__( $body["error"], 'wp-pantheon-decoupled' ) . "</p>\n";
-              if (isset($body["message"]))  {
-                echo "<p>Message: " . esc_html__( $body["message"], 'wp-pantheon-decoupled' ) . "</p>\n";
-              }
-              echo $docs_link;
-            }
-            else {
-              // Success!
-              echo "<p>WordPress was able to communicate with your preview site and preview example content.</p>\n";
-              if (isset($body["message"]))  {
-                echo "<p>Code: {$response['response']['code']}</p>\n";
-                echo "<p>Message: " . esc_html__( $body["message"], 'wp-pantheon-decoupled' ) . "</p>\n";
-              }
-            }
-          ?>
-      </div>
-  <?php
+	// Make test API call.
+	$test_url = $preview_site['url'] . '?secret=' . $preview_site['secret_string'] . '&uri=' . $post->post_name . '&id=' . $post->ID . '&content_type=' . $post_type . '&test=true';
+	$response = wp_remote_get( $test_url );
+	$body     = json_decode( wp_remote_retrieve_body( $response ), true );
+  // phpcs:disable WordPressVIPMinimum.UserExperience.AdminBarRemoval.HidingDetected
+	?>
+		<style>
+		/* Hide admin bar and padding on top of page. */
+		html.wp-toolbar {
+			padding-top: 0;
+		}
+	#wpadminbar {
+			display: none;
+		}
+		</style>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Test Preview Site', 'wp-pantheon-decoupled' ); ?></h1>
+			<?php
+			echo '<h3>' . esc_html(
+			// Translators: %s is the preview site label.
+				sprintf( __( '%s', 'wp-decoupled-preview' ), $preview_site['label'] )
+			) . "</h3>\n";
+			if ( empty( $body ) ) {
+				// We weren't able to reach the preview endpoint at all.
+				echo "<p>There was an error connecting to the preview site.</p>\n";
+				echo '<p>' . esc_html(
+				// Translators: %s is the response code.
+					sprintf( __( 'Code: %s', 'wp-decoupled-preview' ), $response['response']['code'] )
+				) . "</p>\n";
+				echo '<p>' . esc_html(
+				// Translators: %s is the response message.
+					sprintf( __( 'Message: %s', 'wp-decoupled-preview' ), $response['response']['message'] )
+				) . "</p>\n";
+				echo "<p>Consult the Pantheon Documentation for more information on <a href='https://docs.pantheon.io/guides/decoupled/wp-nextjs-frontend-starters/content-preview' target='_blank' rel='noopener noreferrer'>configuring content preview</a>.</p>\n";
+			} elseif ( isset( $body['error'] ) ) {
+				// We were able to reach the preview endpoint, but there was an error.
+				echo '<p>' . esc_html(
+				// Translators: %s is the error.
+					sprintf( __( 'Error: %s', 'wp-decoupled-preview' ), $body['error'] )
+				) . "</p>\n";
+				if ( isset( $body['message'] ) ) {
+					echo '<p>' . esc_html(
+					// Translators: %s is the error message.
+						sprintf( __( 'Message: %s', 'wp-decoupled-preview' ), $body['message'] )
+					) . "</p>\n";
+				}
+				echo "<p>Consult the Pantheon Documentation for more information on <a href='https://docs.pantheon.io/guides/decoupled/wp-nextjs-frontend-starters/content-preview' target='_blank' rel='noopener noreferrer'>configuring content preview</a>.</p>\n";
+			} else {
+				// Success!
+				echo "<p>WordPress was able to communicate with your preview site and preview example content.</p>\n";
+				if ( isset( $body['message'] ) ) {
+					echo '<p>' . esc_html(
+					// Translators: %s is the response code.
+						sprintf( __( 'Code: %s', 'wp-decoupled-preview' ), $response['response']['code'] )
+					) . "</p>\n";
+					echo '<p>' . esc_html(
+					// Translators: %s is the error message.
+						sprintf( __( 'Message: %s', 'wp-decoupled-preview' ), $body['message'] )
+					) . "</p>\n";
+				}
+			}
+			?>
+		</div>
+	<?php
 }
 
+/**
+ * Modal to display environment variables.
+ *
+ * @return void
+ */
 function pantheon_decoupled_env_vars() {
-    if ( ! current_user_can( 'manage_options' ) ) {
-      wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-decoupled-preview' ) );
-    }
-    check_admin_referer( 'env-vars', 'nonce' );
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-decoupled-preview' ) );
+	}
+	check_admin_referer( 'env-vars', 'nonce' );
 
-    // Get data for preview site
-    $id = isset( $_GET['id'] ) ? absint( sanitize_text_field( $_GET['id'] ) ) : NULL;
-    $preview_sites = get_option( 'preview_sites' );
-    $preview_site = isset( $preview_sites['preview'][ $id ] ) ? $preview_sites['preview'][ $id ] : NULL;
+	// Get data for preview site.
+	$id = isset( $_GET['id'] ) ? absint( sanitize_text_field( $_GET['id'] ) ) : null;
+	$preview_sites = get_option( 'preview_sites' );
+	$preview_site = isset( $preview_sites['preview'][ $id ] ) ? $preview_sites['preview'][ $id ] : null;
 
-    global $wp;
-    $home_url = home_url( $wp->request );
+	global $wp;
+	$home_url = home_url( $wp->request );
 
-    ?>
-        <style>
-          /* Hide admin bar and padding on top of page. */
-          html.wp-toolbar {
-            padding-top: 0;
-          }
-          #wpadminbar {
-            display: none;
-          }
-        </style>
-        <div class="wrap">
-            <h1><?php esc_html_e( 'Environment Variables', 'wp-pantheon-decoupled' ); ?></h1>
-            <h4>PREVIEW_SECRET</h4>
-            <?php
-              echo "<p>Value: {$preview_site['secret_string']}</p>\n";
-            ?>
-            <h4>WP_APPLICATION_USERNAME</h4>
-            <?php
-               echo "<p>Value: {$preview_site['associated_user']}</p>\n";
-            ?>
-            <h4>WP_APPLICATION_PASSWORD</h4>
-            <p>The application password associated with this user intended to be used with this preview site.</p>
-            <h4>Linked CMS</h4>
-            <?php
-              echo "<p>Link the CMS site that relates to: <strong>{$home_url}</strong></p>\n";
-            ?>
-        </div>
-    <?php
+	?>
+		<style>
+			/* Hide admin bar and padding on top of page. */
+			html.wp-toolbar {
+			padding-top: 0;
+			}
+			#wpadminbar {
+			display: none;
+			}
+		</style>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Environment Variables', 'wp-pantheon-decoupled' ); ?></h1>
+			<h4>PREVIEW_SECRET</h4>
+			<?php
+			echo '<p>' . esc_html(
+					// Translators: %s is the preview site secret.
+				sprintf( __( 'Value: %s', 'wp-decoupled-preview' ), $preview_site['secret_string'] )
+			) . "</p>\n";
+			?>
+			<h4>WP_APPLICATION_USERNAME</h4>
+			<?php
+			echo '<p>' . esc_html(
+					// Translators: %s is the associated user.
+				sprintf( __( 'Value: %s', 'wp-decoupled-preview' ), $preview_site['associated_user'] )
+			) . "</p>\n";
+			?>
+			<h4>WP_APPLICATION_PASSWORD</h4>
+			<p>The application password associated with this user intended to be used with this preview site.</p>
+			<h4>Linked CMS</h4>
+			<?php
+			echo '<p>Link the CMS site that relates to: <strong>' . esc_html(
+					// Translators: %s is the home url.
+				sprintf( __( '%s', 'wp-decoupled-preview' ), $home_url )
+			) . "</strong></p>\n";
+			?>
+		</div>
+	<?php
 }
 
+/**
+ * Display post install admin notice.
+ *
+ * @return void
+ */
 function pantheon_decoupled_admin_notice() {
-  $add_site_url = wp_nonce_url(
-    add_query_arg( [
-        'page' => 'pantheon-front-end-sites',
-    ], admin_url( 'options-general.php' ) ),
-    'pantheon-front-end-sites',
-    'nonce'
-  );
+	$add_site_url = wp_nonce_url(
+		add_query_arg( [
+			'page' => 'pantheon-front-end-sites',
+		], admin_url( 'options-general.php' ) ),
+		'pantheon-front-end-sites',
+		'nonce'
+	);
 
-  if( !get_transient( 'post_install_next_steps' ) ) {
+	if ( ! get_transient( 'post_install_next_steps' ) ) {
 		?>
 			<div class="notice notice-success notice-alt below-h2">
 				<strong>Pantheon Decoupled Configuration</strong>
 				<p>
 					<label for="pantheon-decoupled-post-install">
-            In order to complete your configuration, visit the <a href="<?php echo esc_url_raw( $add_site_url ); ?>">Front-End Sites Settings</a> page.
+			In order to complete your configuration, visit the <a href="<?php echo esc_url_raw( $add_site_url ); ?>">Front-End Sites Settings</a> page.
 					</label>
 				</p>
 			</div>
 		<?php
-    set_transient('post_install_next_steps', true);
+		set_transient( 'post_install_next_steps', true );
 	}
 }
 
+/**
+ * Callback to redirect to FES settings page when preview sites are updated.
+ *
+ * @return void
+ */
 function pantheon_decoupled_redirect_to_fes() {
-  // If options are being edited on FES settings page, redirect there when
-  // option is updated.
-  $is_fes = isset( $_GET['fes'] ) ? absint( sanitize_text_field( $_GET['fes'] ) ) : NULL;
-  if ( $is_fes ) {
-    wp_redirect( 'options-general.php?page=pantheon-front-end-sites' );
-    exit;
-  }
+	// If options are being edited on FES settings page, redirect there when
+	// option is updated.
+	// A nonce was already used on the options page and we're sanitizing the query
+	// param, so we can safely ignore the phpcs warning.
+  // phpcs:disable WordPress.Security.NonceVerification.Recommended
+	$is_fes = isset( $_GET['fes'] ) ? absint( sanitize_text_field( $_GET['fes'] ) ) : null;
+	if ( $is_fes ) {
+		wp_safe_redirect( 'options-general.php?page=pantheon-front-end-sites' );
+		exit;
+	}
 }
 
-add_action('admin_notices', 'pantheon_decoupled_admin_notice');
-add_action('init', 'pantheon_decoupled_enable_deps');
-add_action( 'admin_menu', 'pantheon_decoupled_settings_init');
+add_action( 'admin_notices', 'pantheon_decoupled_admin_notice' );
+add_action( 'init', 'pantheon_decoupled_enable_deps' );
+add_action( 'admin_menu', 'pantheon_decoupled_settings_init' );
 add_action( 'update_option_preview_sites', 'pantheon_decoupled_redirect_to_fes' );

--- a/pantheon-decoupled.php
+++ b/pantheon-decoupled.php
@@ -194,9 +194,9 @@ function pantheon_decoupled_create_html() {
   check_admin_referer( 'edit-preview-site', 'nonce' );
   $edit_id = isset( $_GET['id'] ) ? sanitize_text_field( $_GET['id'] ) : false;
   if ( $edit_id ) {
-    $action = 'options.php?edit=' . $edit_id;
+    $action = 'options.php?fes=1&edit=' . $edit_id;
   } else {
-    $action = 'options.php';
+    $action = 'options.php?fes=1';
   }
   ?>
   <style>
@@ -204,15 +204,24 @@ function pantheon_decoupled_create_html() {
     Styles here are for ajax version of thickbox. We lose some styles, but gain
     a loading indicator...
     */
-    #TB_window #adminmenumain {
+    #TB_window {
+      background-color: rgb(240, 240, 241);
+    }
+    #TB_window #adminmenumain,
+    #TB_window #wpfooter {
       display: none;
     }
-    #TB_window #wpcontent,
-    #TB_window #wpfooter {
+    #TB_window #wpcontent {
       margin-left: 0;
     }
+    /*
+    Remove back to preview sites link which does't make sense in this
+    context
+    */
+    #TB_window h1 + p a {
+      display: none;
+    }
   </style>
-  <h1>FES Add Preview</h1>
   <div class="wrap">
 				<h1><?php esc_html_e( 'Create or Edit Preview Site', 'wp-decoupled-preview' ); ?></h1>
 				<p><a href="<?php echo esc_url( add_query_arg( 'page', 'preview_sites', admin_url( 'options-general.php' ) ) ); ?>">&larr; <?php esc_html_e( 'Back to Preview Sites Configuration', 'wp-decoupled-preview' ); ?></a></p>
@@ -388,6 +397,18 @@ function pantheon_decoupled_admin_notice() {
     set_transient('post_install_next_steps', true);
 	}
 }
+
+function pantheon_decoupled_redirect_to_fes() {
+  // If options are being edited on FES settings page, redirect there when
+  // option is updated.
+  $is_fes = isset( $_GET['fes'] ) ? absint( sanitize_text_field( $_GET['fes'] ) ) : NULL;
+  if ( $is_fes ) {
+    wp_redirect( 'options-general.php?page=pantheon-front-end-sites' );
+    exit;
+  }
+}
+
 add_action('admin_notices', 'pantheon_decoupled_admin_notice');
 add_action('init', 'pantheon_decoupled_enable_deps');
 add_action( 'admin_menu', 'pantheon_decoupled_settings_init');
+add_action( 'update_option_preview_sites', 'pantheon_decoupled_redirect_to_fes' );

--- a/src/class-fes-preview-table.php
+++ b/src/class-fes-preview-table.php
@@ -5,20 +5,21 @@
  * @package Pantheon_Decoupled
  */
 
- use Pantheon\DecoupledPreview\List_Table;
+use Pantheon\DecoupledPreview\List_Table;
 
 /**
  * List table for displaying the list of sites.
  */
 class FES_Preview_Table extends List_Table {
-  /**
+  // phpcs:disable PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.stringFound
+	/**
 	 * Render a column value.
 	 *
 	 * @param object $item        The item to render.
 	 * @param string $column_name The column name.
 	 * @return string
 	 */
-	public function column_default( $item, $column_name ) : string {
+	public function column_default( $item, $column_name ): string {
 		switch ( $column_name ) {
 			case 'label':
 			case 'url':
@@ -41,17 +42,16 @@ class FES_Preview_Table extends List_Table {
 						'action' => 'test',
 						'id' => $item['id'],
 					], admin_url( 'options-general.php' ) ), 'test-preview-site', 'nonce' ),
-          			esc_html__( 'Test', 'wp-decoupled-preview' ),
+					esc_html__( 'Test', 'wp-decoupled-preview' ),
 					wp_nonce_url( add_query_arg( [
 						'page' => 'env_vars',
 						'action' => 'env',
 						'id' => $item['id'],
 					], admin_url( 'options-general.php' ) ), 'env-vars', 'nonce' ),
-					esc_html__( 'Environment Variables', 'wp-decoupled-preview' ),
+					esc_html__( 'Environment Variables', 'wp-decoupled-preview' )
 				);
 			default:
 				return '';
 		}
 	}
-
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,7 +25,7 @@ require_once "{$_tests_dir}/includes/functions.php";
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
-	require dirname( dirname( __FILE__ ) ) . '/pantheon-decoupled.php';
+	require dirname( __DIR__ ) . '/pantheon-decoupled.php';
 }
 
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );

--- a/tests/test-main.php
+++ b/tests/test-main.php
@@ -8,7 +8,7 @@
  */
 
 
-include __DIR__ . '/../pantheon-decoupled-example.php';
+require __DIR__ . '/../pantheon-decoupled-example.php';
 
 use WP_UnitTestCase;
 
@@ -22,7 +22,7 @@ class Test_Main extends WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_default_options() : void {
+	public function test_default_options(): void {
 		// Set the default options.
 		set_default_options();
 		$options = get_option( 'preview_sites' );


### PR DESCRIPTION
This was way harder than it needed to be :(

* Updated add preview site button on FES settings page to use a modal.
* Implemented modal using ajax rather than an iframe - found that this made it easier to 'break out' of the modal when the form was submitted rather than having actions continue to happen in the iframe.
* Added 'fes=1' query parameter to tell options page that it is being called from the context of FES settings.
* Added `update_option_preview_sites` hook to hijack redirect when a new preview site is added and redirect to FES Settings page.